### PR TITLE
docs(convergent): add live order certification logs for booking 449003

### DIFF
--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,87 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133431712"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+    "roomId": "3107332",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "fd4d7decda224dc5bcc8e533de83dbff",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "商务房（内供）",
+          "nameEn": "Business Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 54.61,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 54.61
+          },
+          "roomId": "3107332"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 489521583,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:37:12 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:37:11.713128+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133431212"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 494884625,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:37:11 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:37:11.213251+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,93 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133430439"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+    "roomId": "3107333",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "2368eeebb4024c9cad88b2a40d7c311c",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "标间（内供）",
+          "nameEn": "Standard Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "cancellationPolicies": [
+              {
+                "amount": 39.25,
+                "from": "2026-05-02T00:00:00.000+08:00"
+              }
+            ],
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 39.25,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 39.25
+          },
+          "roomId": "3107333"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 765880334,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:37:10 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:37:10.441534+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133429676"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 756574583,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:37:09 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:37:09.676631+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/summary.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/summary.json
@@ -1,0 +1,55 @@
+{
+  "timestamp": "2026-04-02T20:37:09+08:00",
+  "credentialId": 25,
+  "credentialName": "TTD Convergent Live",
+  "hotelId": "449003",
+  "outputDir": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_203709",
+  "refundablePick": {
+    "ratePkgId": "Convergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "full",
+    "price": 39.25,
+    "currency": "USD"
+  },
+  "nonRefundablePick": {
+    "ratePkgId": "Convergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "no",
+    "price": 54.61,
+    "currency": "USD"
+  },
+  "cases": [
+    {
+      "caseName": "CaseRefundable",
+      "wantedMode": "full",
+      "selectedRatePkgId": "Convergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+      "selectedRateMode": "full",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "cancelAttempted": false,
+      "cancelSucceeded": false,
+      "bookingError": "Book failed: failed to build book request: missing bookingCode from check avail session",
+      "logFiles": {
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseRefundable/HotelRates_sanitized.json"
+      }
+    },
+    {
+      "caseName": "CaseNonRefundable",
+      "wantedMode": "no",
+      "selectedRatePkgId": "Convergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+      "selectedRateMode": "no",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "cancelAttempted": false,
+      "cancelSucceeded": false,
+      "bookingError": "Book failed: failed to build book request: missing bookingCode from check avail session",
+      "logFiles": {
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_203709/CaseNonRefundable/HotelRates_sanitized.json"
+      }
+    }
+  ]
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/Book_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/Book_sanitized.json
@@ -1,0 +1,88 @@
+{
+  "apiName": "Book",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133954366"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 1,
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775133954366149000",
+    "bookingCode": "623ac69c1056499daa46ada3babef90c",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "childrenAges": null,
+    "contactEmail": "tech@hotelbyte.com",
+    "contactName": "Test User",
+    "contactPhone": "+0 13800138000",
+    "currency": "USD",
+    "dailyPrices": [
+      {
+        "date": "2026-05-02",
+        "price": 54.61,
+        "status": 1
+      }
+    ],
+    "guests": [
+      {
+        "firstName": "Test",
+        "lastName": "Guest",
+        "roomNo": "1"
+      }
+    ],
+    "hotelId": 449003,
+    "nationality": "CN",
+    "orderRoomDetail": {
+      "bedType": "",
+      "broadCode": "BB",
+      "broadCount": 2,
+      "hotelName": "汇智专属酒店(测试)123123",
+      "ratePlanName": "",
+      "roomName": "商务房（内供）"
+    },
+    "password": "REDACTED",
+    "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+    "roomId": "3107332",
+    "rooms": 1,
+    "specialRequests": "",
+    "totalPrice": 54.61,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775133954366149000",
+      "code": 1001,
+      "message": "The selected rooms are no longer available"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 1188327208,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:54 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:54.36663+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/booking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,87 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133952369"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+    "roomId": "3107332",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "623ac69c1056499daa46ada3babef90c",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "商务房（内供）",
+          "nameEn": "Business Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 54.61,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 54.61
+          },
+          "roomId": "3107332"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 1992279500,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:52 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:52.370015+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133935782"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 713627417,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:36 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:35.785622+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/Book_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/Book_sanitized.json
@@ -1,0 +1,88 @@
+{
+  "apiName": "Book",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133937648"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 1,
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775133937648359000",
+    "bookingCode": "726378df77334f8ea31cf783ac7c0aa7",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "childrenAges": null,
+    "contactEmail": "tech@hotelbyte.com",
+    "contactName": "Test User",
+    "contactPhone": "+0 13800138000",
+    "currency": "USD",
+    "dailyPrices": [
+      {
+        "date": "2026-05-02",
+        "price": 39.25,
+        "status": 1
+      }
+    ],
+    "guests": [
+      {
+        "firstName": "Test",
+        "lastName": "Guest",
+        "roomNo": "1"
+      }
+    ],
+    "hotelId": 449003,
+    "nationality": "CN",
+    "orderRoomDetail": {
+      "bedType": "",
+      "broadCode": "BB",
+      "broadCount": 2,
+      "hotelName": "汇智专属酒店(测试)123123",
+      "ratePlanName": "",
+      "roomName": "标间（内供）"
+    },
+    "password": "REDACTED",
+    "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+    "roomId": "3107333",
+    "rooms": 1,
+    "specialRequests": "",
+    "totalPrice": 39.25,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775133937648359000",
+      "code": 1001,
+      "message": "The selected rooms are no longer available"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 2607082833,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:38 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:37.649772+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/booking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,93 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133936507"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+    "roomId": "3107333",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "726378df77334f8ea31cf783ac7c0aa7",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "标间（内供）",
+          "nameEn": "Standard Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "cancellationPolicies": [
+              {
+                "amount": 39.25,
+                "from": "2026-05-02T00:00:00.000+08:00"
+              }
+            ],
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 39.25,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 39.25
+          },
+          "roomId": "3107333"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 1133139916,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:36 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:36.508484+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775133935782"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 713627417,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:45:36 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:45:35.785622+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/summary.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/summary.json
@@ -1,0 +1,57 @@
+{
+  "timestamp": "2026-04-02T20:45:35+08:00",
+  "credentialId": 25,
+  "credentialName": "TTD Convergent Live",
+  "hotelId": "449003",
+  "outputDir": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535",
+  "refundablePick": {
+    "ratePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "full",
+    "price": 39.25,
+    "currency": "USD"
+  },
+  "nonRefundablePick": {
+    "ratePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "no",
+    "price": 54.61,
+    "currency": "USD"
+  },
+  "cases": [
+    {
+      "caseName": "CaseRefundable",
+      "wantedMode": "full",
+      "selectedRatePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+      "selectedRateMode": "full",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "cancelAttempted": false,
+      "cancelSucceeded": false,
+      "bookingError": "Book failed: ErrorCode=[100000404] Message=[order not found by PlatformReferenceNo: -1775133937]",
+      "logFiles": {
+        "Book": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/Book_sanitized.json",
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseRefundable/HotelRates_sanitized.json"
+      }
+    },
+    {
+      "caseName": "CaseNonRefundable",
+      "wantedMode": "no",
+      "selectedRatePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+      "selectedRateMode": "no",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "cancelAttempted": false,
+      "cancelSucceeded": false,
+      "bookingError": "Book failed: ErrorCode=[100000404] Message=[order not found by PlatformReferenceNo: -1775133954]",
+      "logFiles": {
+        "Book": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/Book_sanitized.json",
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_204535/CaseNonRefundable/HotelRates_sanitized.json"
+      }
+    }
+  ]
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Book_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Book_sanitized.json
@@ -1,0 +1,95 @@
+{
+  "apiName": "Book",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134205237"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775134205236930000",
+    "bookingCode": "5aa50073f206473aa8d53a9556460524",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "childrenAges": null,
+    "contactEmail": "tech@hotelbyte.com",
+    "contactName": "Test User",
+    "contactPhone": "+0 13800138000",
+    "currency": "USD",
+    "dailyPrices": [
+      {
+        "date": "2026-05-02",
+        "price": 54.61,
+        "status": 1
+      }
+    ],
+    "guests": [
+      {
+        "firstName": "TestA",
+        "lastName": "Guest",
+        "roomNo": "1"
+      },
+      {
+        "firstName": "TestB",
+        "lastName": "Guest",
+        "roomNo": "1"
+      }
+    ],
+    "hotelId": 449003,
+    "nationality": "CN",
+    "orderRoomDetail": {
+      "bedType": "",
+      "broadCode": "BB",
+      "broadCount": 2,
+      "hotelName": "汇智专属酒店(测试)123123",
+      "ratePlanName": "",
+      "roomName": "商务房（内供）"
+    },
+    "password": "REDACTED",
+    "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+    "roomId": "3107332",
+    "rooms": 1,
+    "specialRequests": "",
+    "totalPrice": 54.61,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775134205236930000",
+      "code": 200,
+      "message": "Booking has been created successfully",
+      "orderId": 8825151,
+      "orderStatus": 1
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 184024792,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:05 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:05.238345+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/booking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Cancel_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Cancel_sanitized.json
@@ -1,0 +1,51 @@
+{
+  "apiName": "Cancel",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134206743"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "agentCode": "TTDB2B",
+    "orderId": 8825151,
+    "password": "REDACTED",
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775134205236930000",
+      "code": 1006,
+      "message": "The order cannot be cancelled",
+      "orderId": 8825151
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 146303208,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:06 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:06.745472+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/cancelbooking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,87 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204963"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+    "roomId": "3107332",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "5aa50073f206473aa8d53a9556460524",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "商务房（内供）",
+          "nameEn": "Business Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 54.61,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 54.61
+          },
+          "roomId": "3107332"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 267140750,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:05 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.963679+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204016"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 321884250,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.01672+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/QueryOrder_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/QueryOrder_sanitized.json
@@ -1,0 +1,63 @@
+{
+  "apiName": "QueryOrder",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134205436"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775134205236930000",
+    "password": "REDACTED",
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "adults": 2,
+      "agentOrderId": "AGENT1775134205236930000",
+      "boardCode": "BB",
+      "boardCount": 2,
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD  ",
+      "hotelId": 449003,
+      "message": "Success",
+      "orderId": 8825151,
+      "orderStatus": 1,
+      "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+      "roomId": "3107332",
+      "rooms": 1,
+      "totalPrice": 54.61
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 61072083,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:05 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:05.436806+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/searchbooking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Book_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Book_sanitized.json
@@ -1,0 +1,95 @@
+{
+  "apiName": "Book",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204444"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775134204444083000",
+    "bookingCode": "cb88fbfb6abf43dd82777e1d342c288d",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "childrenAges": null,
+    "contactEmail": "tech@hotelbyte.com",
+    "contactName": "Test User",
+    "contactPhone": "+0 13800138000",
+    "currency": "USD",
+    "dailyPrices": [
+      {
+        "date": "2026-05-02",
+        "price": 39.25,
+        "status": 1
+      }
+    ],
+    "guests": [
+      {
+        "firstName": "TestA",
+        "lastName": "Guest",
+        "roomNo": "1"
+      },
+      {
+        "firstName": "TestB",
+        "lastName": "Guest",
+        "roomNo": "1"
+      }
+    ],
+    "hotelId": 449003,
+    "nationality": "CN",
+    "orderRoomDetail": {
+      "bedType": "",
+      "broadCode": "BB",
+      "broadCount": 2,
+      "hotelName": "汇智专属酒店(测试)123123",
+      "ratePlanName": "",
+      "roomName": "标间（内供）"
+    },
+    "password": "REDACTED",
+    "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+    "roomId": "3107333",
+    "rooms": 1,
+    "specialRequests": "",
+    "totalPrice": 39.25,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775134204444083000",
+      "code": 200,
+      "message": "Booking has been created successfully",
+      "orderId": 8825150,
+      "orderStatus": 1
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 259606084,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.445489+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/booking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Cancel_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Cancel_sanitized.json
@@ -1,0 +1,52 @@
+{
+  "apiName": "Cancel",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204799"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775134204444083000",
+    "password": "REDACTED",
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "agentOrderId": "AGENT1775134204444083000",
+      "cancellationFees": 0,
+      "code": 200,
+      "message": "Success",
+      "orderId": 8825150
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 151318125,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.80051+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/cancelbooking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/CheckAvail_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/CheckAvail_sanitized.json
@@ -1,0 +1,93 @@
+{
+  "apiName": "CheckAvail",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204346"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelId": 449003,
+    "nationality": "CN",
+    "password": "REDACTED",
+    "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+    "roomId": "3107333",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "bookingCode": "cb88fbfb6abf43dd82777e1d342c288d",
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotel": {
+        "hotelId": 449003,
+        "isFrontDesk": 0,
+        "name": "汇智专属酒店(测试)123123",
+        "nameEn": "Online test123123",
+        "room": {
+          "name": "标间（内供）",
+          "nameEn": "Standard Room",
+          "rate": {
+            "adults": 2,
+            "boardCode": "BB",
+            "boardCount": 2,
+            "cancellationPolicies": [
+              {
+                "amount": 39.25,
+                "from": "2026-05-02T00:00:00.000+08:00"
+              }
+            ],
+            "dailyPrices": [
+              {
+                "date": "2026-05-02",
+                "price": 39.25,
+                "status": 1
+              }
+            ],
+            "isInstantConfirm": true,
+            "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+            "taxDescription": "不包含外国游客旅游税，由酒店收取每晚10林吉特,以酒店收取为准",
+            "totalPrice": 39.25
+          },
+          "roomId": "3107333"
+        }
+      },
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 92489958,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.347059+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/precheck"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/HotelRates_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/HotelRates_sanitized.json
@@ -1,0 +1,148 @@
+{
+  "apiName": "HotelRates",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204016"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "adults": 2,
+    "agentCode": "TTDB2B",
+    "checkIn": "2026-05-02",
+    "checkOut": "2026-05-03",
+    "hotelIds": [
+      449003
+    ],
+    "password": "REDACTED",
+    "rooms": 1,
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD",
+      "hotels": [
+        {
+          "hotelId": 449003,
+          "isFrontDesk": 0,
+          "name": "汇智专属酒店(测试)123123",
+          "nameEn": "Online test123123",
+          "rooms": [
+            {
+              "name": "商务房（内供）",
+              "nameEn": "Business Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 54.61,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107332_3537994_2_1-2_NC_0",
+                  "totalPrice": 54.61
+                }
+              ],
+              "roomId": "3107332"
+            },
+            {
+              "name": "标间（内供）",
+              "nameEn": "Standard Room",
+              "rates": [
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 36.36,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730027_2_0-0_NC_0",
+                  "totalPrice": 36.36
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "BB",
+                  "boardCount": 2,
+                  "cancellationPolicies": [
+                    {
+                      "amount": 39.25,
+                      "from": "2026-05-02T00:00:00.000+08:00"
+                    }
+                  ],
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 39.25,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+                  "totalPrice": 39.25
+                },
+                {
+                  "adults": 2,
+                  "boardCode": "RO",
+                  "boardCount": 0,
+                  "dailyPrices": [
+                    {
+                      "date": "2026-05-02",
+                      "price": 48.53,
+                      "status": 1
+                    }
+                  ],
+                  "isInstantConfirm": true,
+                  "ratePlanCode": "3107333_3730028_2_0-0_NC_0",
+                  "totalPrice": 48.53
+                }
+              ],
+              "roomId": "3107333"
+            }
+          ]
+        }
+      ],
+      "message": "Success"
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 321884250,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.01672+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/hotelSearch"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/QueryOrder_sanitized.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/QueryOrder_sanitized.json
@@ -1,0 +1,69 @@
+{
+  "apiName": "QueryOrder",
+  "curlCommand": "REDACTED",
+  "headers": {
+    "App-Key": "REDACTED",
+    "Content-Type": [
+      "application/json; charset=utf-8"
+    ],
+    "Signature": "REDACTED",
+    "Timestamp": [
+      "1775134204729"
+    ]
+  },
+  "logId": "",
+  "method": "POST",
+  "queryParams": {},
+  "requestBody": {
+    "agentCode": "TTDB2B",
+    "agentOrderId": "AGENT1775134204444083000",
+    "password": "REDACTED",
+    "username": "TTDB2B"
+  },
+  "response": {
+    "body": {
+      "adults": 2,
+      "agentOrderId": "AGENT1775134204444083000",
+      "boardCode": "BB",
+      "boardCount": 2,
+      "cancellationPolicies": [
+        {
+          "amount": 39.25,
+          "from": "2026-05-02T00:00:00.000+08:00"
+        }
+      ],
+      "checkIn": "2026-05-02",
+      "checkOut": "2026-05-03",
+      "code": 200,
+      "currency": "USD  ",
+      "hotelId": 449003,
+      "message": "Success",
+      "orderId": 8825150,
+      "orderStatus": 1,
+      "ratePlanCode": "3107333_3537995_2_1-2_1D0P_0",
+      "roomId": "3107333",
+      "rooms": 1,
+      "totalPrice": 39.25
+    },
+    "contentType": "application/json; charset=utf-8",
+    "duration": 63248083,
+    "headers": {
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Type": [
+        "application/json; charset=utf-8"
+      ],
+      "Date": [
+        "Thu, 02 Apr 2026 12:50:04 GMT"
+      ],
+      "Vary": [
+        "Accept-Encoding"
+      ]
+    },
+    "statusCode": 200
+  },
+  "supplier": "Convergent",
+  "timestamp": "2026-04-02T20:50:04.730189+08:00",
+  "url": "http://hapi.huizhi-intl.com/openapi/v3/searchbooking"
+}

--- a/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/summary.json
+++ b/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/summary.json
@@ -1,0 +1,62 @@
+{
+  "timestamp": "2026-04-02T20:50:04+08:00",
+  "credentialId": 25,
+  "credentialName": "TTD Convergent Live",
+  "hotelId": "449003",
+  "outputDir": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004",
+  "refundablePick": {
+    "ratePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "full",
+    "price": 39.25,
+    "currency": "USD"
+  },
+  "nonRefundablePick": {
+    "ratePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+    "checkIn": 20260502,
+    "checkOut": 20260503,
+    "refundableMode": "no",
+    "price": 54.61,
+    "currency": "USD"
+  },
+  "cases": [
+    {
+      "caseName": "CaseRefundable",
+      "wantedMode": "full",
+      "selectedRatePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107333\u003cHB\u003e3107333_3537995_2_1-2_1D0P_0",
+      "selectedRateMode": "full",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "supplierReferenceNo": "AGENT1775134204444083000",
+      "cancelAttempted": true,
+      "cancelSucceeded": true,
+      "logFiles": {
+        "Book": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Book_sanitized.json",
+        "Cancel": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/Cancel_sanitized.json",
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/HotelRates_sanitized.json",
+        "QueryOrder": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseRefundable/QueryOrder_sanitized.json"
+      }
+    },
+    {
+      "caseName": "CaseNonRefundable",
+      "wantedMode": "no",
+      "selectedRatePkgId": "24\u003cHB\u003e25\u003cHB\u003eConvergent\u003cHB\u003e449003\u003cHB\u003e3107332\u003cHB\u003e3107332_3537994_2_1-2_NC_0",
+      "selectedRateMode": "no",
+      "checkIn": 20260502,
+      "checkOut": 20260503,
+      "supplierReferenceNo": "AGENT1775134205236930000",
+      "cancelAttempted": true,
+      "cancelSucceeded": false,
+      "cancelError": "failed to execute cancel request: ErrorCode=[100001004] Message=[1006:The order cannot be cancelled]",
+      "logFiles": {
+        "Book": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Book_sanitized.json",
+        "Cancel": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/Cancel_sanitized.json",
+        "CheckAvail": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/CheckAvail_sanitized.json",
+        "HotelRates": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/HotelRates_sanitized.json",
+        "QueryOrder": "/Users/bytedance/work/hotel-be/docs/public/certification/convergent/logs/live_ttdb2b_449003_20260402_205004/CaseNonRefundable/QueryOrder_sanitized.json"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add sanitized convergent live certification logs for booking id 449003
- include HotelRates / CheckAvail / Book / QueryOrder / Cancel evidence bundles

## Notes
- generated from live-order verification run on 2026-04-02